### PR TITLE
feat: auto-detect package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Add a `.types-syncrc.json` at the root of your project.
 | packageManager | `npm`/`yarn`/`pnpm`/`bolt` | package manager to use                  |
 | removeUnused   | `Boolean`                  | remove unsued types                     |
 
-Note: `types-sync` will automatically detect the package manager beign used. Explicitly Defining the
-`packageManager` is optional and if defined will force `types-sync` to use that package manager.
+Note: `types-sync` will automatically detect the package manager being used. Explicitly Defining the
+`packageManager` config option is optional and if defined will force `types-sync` to use the
+specified package manager.
 
 Refer to
 [./types-syncrc.json](https://github.com/maddhruv/types-sync/blob/master/.types-syncrc.json) for

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Add a `.types-syncrc.json` at the root of your project.
 | packageManager | `npm`/`yarn`/`pnpm`/`bolt` | package manager to use                  |
 | removeUnused   | `Boolean`                  | remove unsued types                     |
 
+Note: `types-sync` will automatically detect the package manager beign used. Explicitly Defining the
+`packageManager` is optional and if defined will force `types-sync` to use that package manager.
+
 Refer to
 [./types-syncrc.json](https://github.com/maddhruv/types-sync/blob/master/.types-syncrc.json) for
 full config

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Add a `.types-syncrc.json` at the root of your project.
 | packageManager | `npm`/`yarn`/`pnpm`/`bolt` | package manager to use                  |
 | removeUnused   | `Boolean`                  | remove unsued types                     |
 
-Note: `types-sync` will automatically detect the package manager being used. Explicitly Defining the
-`packageManager` config option is optional and if defined will force `types-sync` to use the
-specified package manager.
+Note: `types-sync` will automatically detect the package manager being used according to the lock
+files. Explicitly defining the `packageManager` config option is optional and if defined will force
+`types-sync` to use the specified package manager.
 
 Refer to
 [./types-syncrc.json](https://github.com/maddhruv/types-sync/blob/master/.types-syncrc.json) for

--- a/bin/types-sync.js
+++ b/bin/types-sync.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 const { execSync } = require('child_process');
+const path = require('path');
 const fs = require('fs');
 const chalk = require('chalk');
 const cosmiconfig = require('cosmiconfig');
+const findUp = require('find-up');
 
 const { typesSync } = require('../dist');
 
@@ -24,7 +26,17 @@ const explorer = cosmiconfig('types-sync');
       ignore: [...(config.ignore || [])],
     });
 
-    const packageManager = config.packageManager || 'npm';
+    let agent = 'npm'
+    if (!config.packageManager) {
+      const LOCKS = {
+        'pnpm-lock.yaml': 'pnpm',
+        'yarn.lock': 'yarn',
+        'package-lock.json': 'npm',
+      };
+      const result = await findUp(Object.keys(LOCKS));
+      agent = result ? LOCKS[path.basename(result)] : 'npm';
+    }
+    const packageManager = config.packageManager || agent;
 
     let installer = 'npm i -D',
       uninstaller = 'npm uninstall';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "chalk": "^4.1.1",
         "cosmiconfig": "^5.2.1",
+        "find-up": "^4.1.0",
         "isomorphic-fetch": "^3.0.0"
       },
       "bin": {
@@ -7435,7 +7436,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -10228,7 +10228,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -11436,7 +11435,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -11451,7 +11449,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -11463,7 +11460,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11817,7 +11813,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -26378,7 +26373,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -28595,7 +28589,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "requires": {
         "p-locate": "^4.1.0"
       }
@@ -29576,7 +29569,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -29585,7 +29577,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
       }
@@ -29593,8 +29584,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-json": {
       "version": "6.5.0",
@@ -29902,8 +29892,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "chalk": "^4.1.1",
     "cosmiconfig": "^5.2.1",
+    "find-up": "^4.1.0",
     "isomorphic-fetch": "^3.0.0"
   },
   "maintainers": [


### PR DESCRIPTION
Only If the `.types-syncrc.json` config file is not present or if the `"packageManager"` key on it is not defined, then the package manager will be auto-detected based on the lock file.